### PR TITLE
Minor update based on the release of the package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - version: '1.9'  # 1.9
             os: ubuntu-latest
             arch: x86
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
+          # - version: 'nightly'
+          #   os: ubuntu-latest
+          #   arch: x64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
           - version: '1.9'  # 1.9
             os: ubuntu-latest
             arch: x86
-          # - version: 'nightly'
-          #   os: ubuntu-latest
-          #   arch: x64
+          - version: 'nightly'
+            os: ubuntu-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Unversioned
 
+* Adjusted documentation to deploy to the proper site.
+* Removed pre-release statements.
+
+## Version 0.7.0 (2024-08-15)
+
 ### Feature
 
 * Added support for `CaptureProcessEmissions` for `CCSRetroFit` nodes.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ These technologies are
 `RefNetworkNodeRetrofit` and `CCSRetroFit` have to be coupled to each other for proper functioning as they require a proxy resource for CO2.
 Further information can be found in the _[corresponding documentation](https://energymodelsx.github.io/EnergyModelsCO2.jl/stable/)_.
 
-> **Note**
->
-> This is an internal pre-release not intended for distribution outside the project consortium.
+> **Note**:
+> The stable docs are in the current version not working due to a mistake in the deploy.
+> It will be updated in the next release.
 
 ## Usage
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,5 +63,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo = "github.com/EnergyModelsX/EnergyModelsCO2.git",
+    repo = "github.com/EnergyModelsX/EnergyModelsCO2.jl.git",
 )

--- a/docs/src/manual/quick-start.md
+++ b/docs/src/manual/quick-start.md
@@ -15,10 +15,3 @@
 >    ] add EnergyModelsCO2
 >    ```
 >
-
-!!! note
-    If you receive the error that `EnergyModelsCO2` is not yet registered, you have to add the package using the GitHub repository through
-    ```
-    ] add https://github.com/EnergyModelsX/EnergyModelsCO2
-    ```
-    Once the package is registered, this is not required.


### PR DESCRIPTION
This PR removes some parts that are no longer relevant after the release of the package.
In addition, the documentation was updated based on the change of the repository name (Inclusion of `.jl`). As a consequence, the stable documentation is not yet available without reregistering the package.