### PR TITLE
Improvement of input/output dictionary for retrofit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # Release Notes
 
-## Unversioned
+## Version 0.7.1 (2024-08-16)
+
+* Removed requirement for specifying the `co2_proxy` resource as output of the `NetworkNodeWithRetrofit` node and input to the `CCSRetroFit` node through addding methods for `EMB.outputs` and `EMB.inputs`.
+  This implies that both are no longer specified within the `input` and `output` dictionary, and all functionality directly accessing the fields may result in errors.
+* Adjusted documentation to deploy to the proper site.
+* Removed pre-release statements.
+
+## Version 0.7.0 (2024-08-15)
 
 * Adjusted documentation to deploy to the proper site.
 * Removed pre-release statements.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCO2"
 uuid = "84b3f4d7-d799-4a5d-b06c-25c90dcfcad7"
 authors = ["Sigmund Eggen Holm <sigmund.holm@sintef.no> and contributors"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/library/internals/d-methods-EMB.md
+++ b/docs/src/library/internals/d-methods-EMB.md
@@ -26,6 +26,8 @@ EnergyModelsBase.constraints_data
 
 ```@docs
 EnergyModelsBase.previous_level
+EnergyModelsBase.inputs
+EnergyModelsBase.outputs
 ```
 
 ## Check methods

--- a/docs/src/nodes/retrofit.md
+++ b/docs/src/nodes/retrofit.md
@@ -58,9 +58,11 @@ The standard fields are given as:
   All values have to be non-negative.
   !!! info "Meaning in boths nodes"
       - [`RefNetworkNodeRetrofit`](@ref):\
-        Requires the incorporation of the CO₂ proxy resource in the `output` dictionary, although the exact value is not relevant.
+        No special meaning.
+        The CO₂ proxy resource is automatically included in the `output` dictionary through providing additional methods to `EMB.outputs`.
       - [`CCSRetroFit`](@ref):\
-        Requires the incorporation of the CO₂ proxy resource in the `input` dictionary and the CO₂ resource in the `output` dictionary, although the exact values are not relevant.
+        The CO₂ proxy resource is automatically included in the `input` dictionary through providing additional methods to `EMB.inputs`.
+        Requires the incorporation of the  CO₂ resource in the `output` dictionary, although the exact value is not relevant.
         It is furthermore possible to specify additional reenergy required for capturing CO₂ using a conversion factor (*e.g.*, MWh/t CO₂).
 - **`data::Vector{Data}`**:\
   An entry for providing additional data to the model.
@@ -396,7 +398,7 @@ This constraint is given by:
 
 ```math
 \texttt{flow\_in}[n, t, p] =
-outputs(n, p) \times \texttt{cap\_use}[n, t]
+inputs(n, p) \times \texttt{cap\_use}[n, t]
 \qquad \forall p \in inputs(n) \setminus \{co2\_proxy(n)\}
 ```
 

--- a/examples/ccs_retrofit.jl
+++ b/examples/ccs_retrofit.jl
@@ -74,9 +74,9 @@ function generate_co2_retrofit_example_data()
             FixedProfile(5.5),          # Variable OPEX in €/MWh
             FixedProfile(0),            # Fixed OPEX in €/MW/a
             Dict(NG => 1.66),           # Input to the node with input ratio
-            Dict(Power => 1, CO2_proxy => 0), # Output from the node with input ratio
-            # Line above: CO2_proxy is required as output for variable definition, but the
-            # value does not matter
+            Dict(Power => 1),           # Output from the node with input ratio
+            # Line above: CO2_proxy does not have to be specified as we add a method to
+            # `EMB.outputs`
             CO2_proxy,                  # Instance of the `CO2_proxy`
             Data[CaptureEnergyEmissions(1.0)], # Capture data for the node.
             # All energy emissions are captured
@@ -87,8 +87,7 @@ function generate_co2_retrofit_example_data()
             FixedProfile(0),            # Variable OPEX in €/t
             FixedProfile(0),            # Fixed OPEX in €/(t/h)/a
             Dict(NG => 1.0, CO2_proxy => 0), # Input to the node with input ratio
-            # Line above: CO2_proxy is required as input for variable definition, but the
-            # value does not matter
+            # Line above: CO2_proxy is not required as input as we utilize an inner constructor
             Dict(CO2 => 0),
             # Line above: CO2 is required as input for variable definition, but the
             # value does not matter

--- a/src/data_functions.jl
+++ b/src/data_functions.jl
@@ -1,6 +1,13 @@
 
 """
-    EMB.constraints_data(m, n::NetworkNodeWithRetrofit, 𝒯, 𝒫, modeltype, data::EmissionsData)
+    EMB.constraints_data(
+    m,
+    n::NetworkNodeWithRetrofit,
+    𝒯,
+    𝒫,
+    modeltype::EnergyModel,
+    data::EmissionsData
+)
 
 Constraints functions for calculating both the emissions and amount of CO₂ captured in the
 process when CO₂ capture is included as retrofit. It works similar to the approach of
@@ -14,7 +21,7 @@ function EMB.constraints_data(
     n::NetworkNodeWithRetrofit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureProcessEnergyEmissions,
 )
 
@@ -49,7 +56,7 @@ function EMB.constraints_data(
     n::NetworkNodeWithRetrofit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureEnergyEmissions,
 )
 
@@ -85,7 +92,7 @@ function EMB.constraints_data(
     n::NetworkNodeWithRetrofit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureProcessEmissions,
 )
 
@@ -118,7 +125,7 @@ function EMB.constraints_data(
 end
 
 """
-    EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::EmissionsData)
+    EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsData)
 
 Constraints functions for calculating both the emissions and amount of CO₂ captured in the
 CO₂ capture unit.
@@ -141,14 +148,14 @@ function EMB.constraints_data(
     n::CCSRetroFit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureProcessEnergyEmissions,
 )
 
     # Declaration of the required subsets.
     CO2 = co2_instance(modeltype)
     CO2_proxy = co2_proxy(n)
-    𝒫ⁱⁿ = inputs(n)
+    𝒫ⁱⁿ = setdiff(inputs(n), [CO2_proxy])
     𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
     # Calculate the total amount of CO2 to be considered for capture
@@ -193,14 +200,14 @@ function EMB.constraints_data(
     n::CCSRetroFit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureEnergyEmissions,
 )
 
     # Declaration of the required subsets.
     CO2 = co2_instance(modeltype)
     CO2_proxy = co2_proxy(n)
-    𝒫ⁱⁿ = inputs(n)
+    𝒫ⁱⁿ = setdiff(inputs(n), [CO2_proxy])
     𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
     # Calculate the total amount of CO2 to be considered for capture
@@ -244,14 +251,14 @@ function EMB.constraints_data(
     n::CCSRetroFit,
     𝒯,
     𝒫,
-    modeltype,
+    modeltype::EnergyModel,
     data::CaptureProcessEmissions,
 )
 
     # Declaration of the required subsets.
     CO2 = co2_instance(modeltype)
     CO2_proxy = co2_proxy(n)
-    𝒫ⁱⁿ = inputs(n)
+    𝒫ⁱⁿ = setdiff(inputs(n), [CO2_proxy])
     𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
     # Calculate the total amount of CO2 to be considered for capture
@@ -289,12 +296,12 @@ function EMB.constraints_data(
             )
     )
 end
-function EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureFlueGas)
+function EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureFlueGas)
 
     # Declaration of the required subsets.
     CO2 = co2_instance(modeltype)
     CO2_proxy = co2_proxy(n)
-    𝒫ⁱⁿ = inputs(n)
+    𝒫ⁱⁿ = setdiff(inputs(n), [CO2_proxy])
     𝒫ᵉᵐ = setdiff(filter(EMB.is_resource_emit, 𝒫), [CO2])
 
     # Calculate the total amount of CO2 to be considered for capture

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -143,6 +143,8 @@ It corresponds to a [`RefNetworkNode`](@extref EnergyModelsBase.RefNetworkNode) 
 which the CO₂ is not emitted. Instead, it is transferred to a `co2_proxy` that is fed
 subsequently to a node ([`CCSRetroFit`](@ref)) in which it is either captured, or emitted.
 
+The `co2_proxy` does not have to be specified as `output` resource.
+
 # Fields
 - **`id`** is the name/identifier of the node.
 - **`cap::TimeProfile`** is the installed capacity.
@@ -166,11 +168,16 @@ struct RefNetworkNodeRetrofit <: NetworkNodeWithRetrofit
     data::Array{<:Data}
 end
 
+EMB.outputs(n::NetworkNodeWithRetrofit) = unique(append!(Resource[n.co2_proxy], keys(n.output)))
+EMB.outputs(n::NetworkNodeWithRetrofit, p::Resource) = haskey(n.output, p) ? n.output[p] : 0
+
 """
     CCSRetroFit <: Network
 
 This node allows for investments into CO₂ capture retrofit to a [`RefNetworkNodeRetrofit`](@ref)
 node. The capture process is implemented through the variable `:cap_use`
+
+The `co2_proxy` does not have to be specified as `input` resource.
 
 # Fields
 - **`id`** is the name/identifier of the node.
@@ -195,6 +202,9 @@ struct CCSRetroFit <: NetworkNode
     co2_proxy::Resource
     data::Array{<:Data}
 end
+
+EMB.inputs(n::CCSRetroFit) = unique(append!(Resource[n.co2_proxy], keys(n.input)))
+EMB.inputs(n::CCSRetroFit, p::Resource) = haskey(n.input, p) ? n.input[p] : 0
 
 """
     co2_proxy(n::EMB.Node)

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -168,7 +168,19 @@ struct RefNetworkNodeRetrofit <: NetworkNodeWithRetrofit
     data::Array{<:Data}
 end
 
+"""
+    EMB.outputs(n::CCSRetroFit)
+
+When the node is a [`NetworkNodeWithRetrofit`](@ref), it returns the `co2_proxy` resource in
+addition to the keys of the `output` dictionary.
+"""
 EMB.outputs(n::NetworkNodeWithRetrofit) = unique(append!(Resource[n.co2_proxy], keys(n.output)))
+"""
+    EMB.outputs(n::NetworkNodeWithRetrofit, p::Resource)
+
+When the node is a [`NetworkNodeWithRetrofit`](@ref), it returns the value of `output`
+resource `p`. If `p` is the `co2_proxy` resource, it returns 0.
+"""
 EMB.outputs(n::NetworkNodeWithRetrofit, p::Resource) = haskey(n.output, p) ? n.output[p] : 0
 
 """
@@ -203,7 +215,19 @@ struct CCSRetroFit <: NetworkNode
     data::Array{<:Data}
 end
 
+"""
+    EMB.inputs(n::CCSRetroFit)
+
+When the node is a [`CCSRetroFit`](@ref), it returns the `co2_proxy` resource in addition to
+the keys of the `input` dictionary.
+"""
 EMB.inputs(n::CCSRetroFit) = unique(append!(Resource[n.co2_proxy], keys(n.input)))
+"""
+    EMB.inputs(n::CCSRetroFit, p::Resource)
+
+When the node is a [`CCSRetroFit`](@ref), it returns the value of `input` resource `p`.
+If `p` is the `co2_proxy` resource, it returns 0.
+"""
 EMB.inputs(n::CCSRetroFit, p::Resource) = haskey(n.input, p) ? n.input[p] : 0
 
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -76,8 +76,8 @@ Set all constraints for a `CCSRetroFit`.
 function EMB.create_node(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel)
 
     # Declaration of the required subsets
-    𝒫ⁱⁿ = inputs(n)
     CO2_proxy = co2_proxy(n)
+    𝒫ⁱⁿ = setdiff(inputs(n), [CO2_proxy])
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
 
     # Iterate through all data and set up the constraints corresponding to the data
@@ -87,7 +87,7 @@ function EMB.create_node(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel)
 
     # Inlet constraints for all other resources
     # The value for `CO2_proxy` is calculated in `constraints_data`.
-    @constraint(m, [t ∈ 𝒯, p ∈ EMB.res_not(𝒫ⁱⁿ, CO2_proxy)],
+    @constraint(m, [t ∈ 𝒯, p ∈ 𝒫ⁱⁿ],
         m[:flow_in][n, t, p] == m[:cap_use][n, t] * inputs(n, p)
     )
 

--- a/test/test_ccs_retrofit.jl
+++ b/test/test_ccs_retrofit.jl
@@ -20,7 +20,7 @@ function CO2_retrofit(emissions_data; process_unit=nothing)
             FixedProfile(5.5),
             FixedProfile(0),
             Dict(NG => 2),
-            Dict(Power => 1, CO2_proxy => 0),
+            Dict(Power => 1),
             CO2_proxy,
             [emissions_data["process"]],
         )
@@ -31,7 +31,7 @@ function CO2_retrofit(emissions_data; process_unit=nothing)
         FixedProfile(5),
         FixedProfile(0),
         FixedProfile(0),
-        Dict(NG => 0.05, CO2_proxy => 0),
+        Dict(NG => 0.05),
         Dict(CO2 => 0),
         CO2_proxy,
         [emissions_data["ccs"]],
@@ -351,7 +351,7 @@ end
         FixedProfile(5.5),
         FixedProfile(0),
         Dict(NG => 2),
-        Dict(Power => 1, CO2_proxy => 0),
+        Dict(Power => 1),
         CO2_proxy,
         [CaptureEnergyEmissions(Dict(CO2 => 0.1), 0.9)],
     )


### PR DESCRIPTION
Previously, it was necessary to specify the `co2_proxy` resource in the `output` and `input` dictionaries of  `NetworkNodeWithRetrofit` and `CCSRetroFit`, respectively. The exact value did not matter, but it was necessary for the declaration of the flow variables.

This PR is providing a new approach in which we utilize dispatch on the functions `EMB.inputs` and EMB.outputs` to automatically add the  `co2_proxy` resource.