### PR TITLE
Enhancement of CO2 Storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
             os: ubuntu-latest
             arch: x64
           - version: 'lts'  # lts
-            os: ubuntu-latest
-            arch: x86
+            os: windows-latest
+            arch: x64
           # - version: 'nightly'
           #   os: ubuntu-latest
           #   arch: x64

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Version 0.7.4 (2024-11-29)
+
+* Included changes for `CO2Storage` to not require the definition of variables that are not used.
+* Included check changes from `EnergyModelsBase`.
+
 ## Version 0.7.3 (2024-10-16)
 
 * Minor changes to the documentation and docstrings.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Included changes for `CO2Storage` to not require the definition of variables that are not used.
 * Included check changes from `EnergyModelsBase`.
+* Fixed minor errors in the documentation.
 
 ## Version 0.7.3 (2024-10-16)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCO2"
 uuid = "84b3f4d7-d799-4a5d-b06c-25c90dcfcad7"
-authors = ["Sigmund Eggen Holm <sigmund.holm@sintef.no> and contributors"]
-version = "0.7.3"
+authors = ["Sigmund Eggen Holm, Julian Straus"]
+version = "0.7.4"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -10,7 +10,7 @@ SparseVariables = "2749762c-80ed-4b14-8f33-f0736679b02b"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.8.1"
+EnergyModelsBase = "0.8.3"
 JuMP = "1.5"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/docs/src/nodes/retrofit.md
+++ b/docs/src/nodes/retrofit.md
@@ -75,9 +75,9 @@ The standard fields are given as:
       - [`CCSRetroFit`](@ref):\
         The capture rate corresponds to
         1. the fraction captured from the flue gas ([`CaptureFlueGas`](@ref)),
-        2. the fraction captured from the flue gas and the energy input to the unit ([`CaptureEnergyEmissions`](@ref)),
-        3. the fraction captured from the flue gas and the process emissions ([`CaptureProcessEmissions`](@ref)), or
-        4. the fraction captured from the flue gas, the energy input to the unit, and the process emissions ([`CaptureProcessEnergyEmissions`](@ref))
+        2. the fraction captured from the flue gas and the energy input to the unit ([`CaptureEnergyEmissions`](@extref EnergyModelsBase.CaptureEnergyEmissions)),
+        3. the fraction captured from the flue gas and the process emissions ([`CaptureProcessEmissions`](@extref EnergyModelsBase.CaptureProcessEmissions)), or
+        4. the fraction captured from the flue gas, the energy input to the unit, and the process emissions ([`CaptureProcessEnergyEmissions`](@extref EnergyModelsBase.CaptureProcessEnergyEmissions))
 
 ### [Additional fields](@id nodes-CCS_retrofit-fields-new)
 

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -120,7 +120,7 @@ These standard constraints are:
   ```
 
   !!! tip "Why do we use `first()`"
-      The variable ``\texttt{cap\_inst}`` is declared over all operational periods (see the section on *[Capacity variables](@ref man-opt_var-cap)* for further explanations).
+      The variable ``\texttt{cap\_inst}`` is declared over all operational periods (see the section on *[Capacity variables](@extref EnergyModelsBase man-opt_var-cap)* for further explanations).
       Hence, we use the function ``first(t_{inv})`` to retrieve the installed capacity in the first operational period of a given strategic period ``t_{inv}`` in the function `constraints_opex_fixed`.
 
 - `constraints_opex_var`:

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -24,10 +24,10 @@ The standard fields are given as:
 - **`id`**:\
   The field `id` is only used for providing a name to the node. This is similar to the approach utilized in `EnergyModelsBase`.
 - **`charge::EMB.UnionCapacity`**:\
-  The charge storage parameters must include a capacity for charging.
+  The charge storage parameters must include a capacity.
   More information can be found on *[storage parameters](@extref EnergyModelsBase lib-pub-nodes-stor_par)*.
 - **`level::EMB.UnionCapacity`**:\
-  The level storage parameters must include a capacity for charging.
+  The level storage parameters must include a capacity.
   More information can be found on *[storage parameters](@extref EnergyModelsBase lib-pub-nodes-stor_par)*.
   !!! note "Permitted values for storage parameters in `charge` and `level`"
       If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -1,8 +1,11 @@
 """
     EMB.check_node(n::CO2Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-This method checks that a [`CO2Source`](@ref) node is valid. It is a repetition of the
-standard checks for a `Source` node, but adds an additional check on the data.
+This method checks that a [`CO2Source`](@ref) node is valid.
+
+It reuses the standard checks of a `Source` node through calling the function
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
+additional check on the data.
 
 ## Checks
  - The field `cap` is required to be non-negative.
@@ -14,17 +17,7 @@ standard checks for a `Source` node, but adds an additional check on the data.
 """
 function EMB.check_node(n::CO2Source, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 
-    𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-
-    @assert_or_log(
-        sum(capacity(n, t) ≥ 0 for t ∈ 𝒯) == length(𝒯),
-        "The capacity must be non-negative."
-    )
-    @assert_or_log(
-        sum(outputs(n, p) ≥ 0 for p ∈ outputs(n)) == length(outputs(n)),
-        "The values for the Dictionary `output` must be non-negative."
-    )
-    EMB.check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)
+    EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
     @assert_or_log(
         !any(typeof.(node_data(n)) .<: CaptureData),
         "The `data` cannot include a `CaptureData`."

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -79,7 +79,6 @@ struct CO2Storage{T} <: Storage{T}
 
     stor_res::ResourceEmit
     input::Dict{<:Resource,<:Real}
-    output::Dict{<:Resource,<:Real}
     data::Array{<:Data}
 
     function CO2Storage(
@@ -96,7 +95,6 @@ struct CO2Storage{T} <: Storage{T}
             level,
             stor_res,
             input,
-            Dict(stor_res => 0),
             data
         )
     end
@@ -118,6 +116,18 @@ function CO2Storage(
     )
 end
 EMB.has_emissions(n::CO2Storage) = true
+EMB.has_output(n::CO2Storage) = false
+
+"""
+    EMB.outputs(n::CO2Storage)
+    EMB.outputs(n::CO2Storage, p::Resource)
+
+When the node is a [`CO2Storage`](@ref), it returns an empty array.
+
+If the resource `p` is specified, it returns a value of 0.
+"""
+EMB.outputs(n::CO2Storage) = Resource[]
+EMB.outputs(n::CO2Storage, p::Resource) = 0
 
 """
     NetworkNodeWithRetrofit <:NetworkNode

--- a/src/model.jl
+++ b/src/model.jl
@@ -60,9 +60,6 @@ function EMB.create_node(m, n::CO2Storage, 𝒯, 𝒫, modeltype::EnergyModel)
     # The CO2Storage has no outputs.
     for t ∈ 𝒯
         fix(m[:stor_discharge_use][n, t], 0,; force=true)
-        for p ∈ outputs(n)
-            fix(m[:flow_out][n, t, p], 0,; force=true)
-        end
     end
 
     # Bounds for the storage level and storage rate used.


### PR DESCRIPTION
Previously, `CO2Storage` had an output flow fixed to a value of 0. The reason for this approach was that `CO2Storage <: Storage <: NetworkNode`. The internal constructor however already enforced that one could not specify the output resources.

This was now changed through new methods for `EMB.outputs` and `EMB.has_output`.