### PR TITLE
Adjustment to EMB v0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Version 0.7.6 (2025-02-10)
+
+* Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
+  * Increased version nubmer for EMB.
+  * Model worked without adjustments.
+  * Adjustments only required for simple understanding of changes.
+
 ## Version 0.7.5 (2024-11-03)
 
 * Fix of a bug introduced in 0.7.4.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCO2"
 uuid = "84b3f4d7-d799-4a5d-b06c-25c90dcfcad7"
 authors = ["Sigmund Eggen Holm, Julian Straus"]
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SparseVariables = "2749762c-80ed-4b14-8f33-f0736679b02b"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.8.3"
+EnergyModelsBase = "0.9"
 JuMP = "1.5"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/examples/ccs_retrofit.jl
+++ b/examples/ccs_retrofit.jl
@@ -125,13 +125,8 @@ function generate_co2_retrofit_example_data()
         Direct("ccs-storage", nodes[3], nodes[4], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -147,8 +142,8 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_co2_retrofit_results(m, case)
     # Extract the nodes and the strategic periods from the data
-    ccgt, ccs = case[:nodes][[2,3]]
-    CO2, CO2_proxy, NG, Power = case[:products]
+    ccgt, ccs = get_nodes(case)[[2,3]]
+    CO2, CO2_proxy, NG, Power = get_products(case)
 
     ccgt_out = sort(                    # Outlet CO₂ flow from the CCGT
             JuMP.Containers.rowtable(

--- a/examples/co2_storage.jl
+++ b/examples/co2_storage.jl
@@ -80,13 +80,8 @@ function generate_co2_storage_example_data()
         Direct("source-storage", nodes[1], nodes[2], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -102,8 +97,8 @@ Function for processing the results to be represented in the a table afterwards.
 """
 function process_co2_storage_results(m, case)
     # Extract the nodes and the strategic periods from the data
-    co2_stor  = case[:nodes][2]
-    𝒯ᴵⁿᵛ = strategic_periods(case[:T])
+    co2_stor  = get_nodes(case)[2]
+    𝒯ᴵⁿᵛ = strategic_periods(get_time_struct(case))
 
     # Extract the first operational period of each strategic period
     first_op = [first(t_inv) for t_inv ∈ 𝒯ᴵⁿᵛ]

--- a/test/test_ccs_retrofit.jl
+++ b/test/test_ccs_retrofit.jl
@@ -70,8 +70,7 @@ function CO2_retrofit(emissions_data; process_unit=nothing)
     modeltype =
         OperationalModel(Dict(CO2 => FixedProfile(60)), Dict(CO2 => FixedProfile(30)), CO2)
 
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
-
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     m = EMB.run_model(case, modeltype, HiGHS.Optimizer)
 
     return m, case, modeltype
@@ -80,8 +79,8 @@ end
 function general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # General tests of the results and that the model producses
     @test termination_status(m) == MOI.OPTIMAL
@@ -99,8 +98,8 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
     # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
@@ -151,8 +150,8 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
     # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
@@ -210,8 +209,8 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
     # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
@@ -268,8 +267,8 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
     # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
@@ -354,8 +353,8 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    process, ccs = case[:nodes][[2,3]]
-    T = case[:T]
+    process, ccs = get_nodes(case)[[2,3]]
+    T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
     # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)

--- a/test/test_ccs_retrofit.jl
+++ b/test/test_ccs_retrofit.jl
@@ -53,7 +53,6 @@ function CO2_retrofit(emissions_data; process_unit=nothing)
     )
 
     nodes = [
-        GenAvailability(1, products),
         ng_source,
         process_unit,
         ccs_unit,
@@ -66,7 +65,6 @@ function CO2_retrofit(emissions_data; process_unit=nothing)
         Direct("pu-demand", process_unit, demand)
         Direct("pu-ccs", process_unit, ccs_unit)
         Direct("ccs-co2", ccs_unit, co2_storage)
-        Direct("co2-av", co2_storage, nodes[1])
     ]
 
     modeltype =
@@ -82,9 +80,7 @@ end
 function general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # General tests of the results and that the model producses
@@ -103,9 +99,7 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # Test that the outflow of the proxy is correct based on the capture rate
@@ -157,9 +151,7 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # Test that the outflow of the proxy is correct based on the capture rate
@@ -218,9 +210,7 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # Test that the outflow of the proxy is correct based on the capture rate
@@ -278,9 +268,7 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # Test that the outflow of the proxy is correct based on the capture rate
@@ -366,9 +354,7 @@ end
     general_tests(m, case, modeltype)
 
     # Extract the input data
-    nodes = case[:nodes]
-    process = nodes[3]
-    ccs = nodes[4]
+    process, ccs = case[:nodes][[2,3]]
     T = case[:T]
 
     # Test that the outflow of the proxy is correct based on the capture rate

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -37,12 +37,7 @@ EMB.TEST_ENV = true
             Dict(CO2 => FixedProfile(0)),
             CO2
         )
-        case = Dict(
-                    :T => T,
-                    :nodes => nodes,
-                    :links => links,
-                    :products => resources,
-        )
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, model), case, model
     end
 

--- a/test/test_co2storage.jl
+++ b/test/test_co2storage.jl
@@ -39,8 +39,7 @@ function small_graph(T; source_cap = 9)
 
     modeltype =
         OperationalModel(Dict(CO2 => FixedProfile(3)), Dict(CO2 => FixedProfile(20)), CO2)
-
-    case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, modeltype
 end
 
@@ -51,8 +50,8 @@ end
     case, modeltype = small_graph(T)
     m = EMB.run_model(case, modeltype, HiGHS.Optimizer)
 
-    nodes = case[:nodes]
-    T = case[:T]
+    nodes = get_nodes(case)
+    T = get_time_struct(case)
 
     source = nodes[1]
     storage = nodes[2]
@@ -93,8 +92,8 @@ end
     case, modeltype = small_graph(T, source_cap = source_cap)
     m = EMB.run_model(case, modeltype, HiGHS.Optimizer)
 
-    nodes = case[:nodes]
-    T = case[:T]
+    nodes = get_nodes(case)
+    T = get_time_struct(case)
 
     source = nodes[1]
     storage = nodes[2]
@@ -130,8 +129,8 @@ end
     case, modeltype = small_graph(T, source_cap = source_cap)
     m = EMB.run_model(case, modeltype, HiGHS.Optimizer)
 
-    nodes = case[:nodes]
-    T = case[:T]
+    nodes = get_nodes(case)
+    T = get_time_struct(case)
 
     source = nodes[1]
     storage = nodes[2]


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [`v0.9.0 EnergyModelsBase`](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0) 

The adjustments required minor changes in the design of the individual tests and examples. It did not require any changes to the code itself.