### PR TITLE
Adjustment to EMB v0.10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,19 @@
 # Release Notes
 
+## Unversioned
+
+* Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):
+  * Model worked without adjustments.
+  * Adjustments required due to different behavior when investments are included due to the change in [`EnergyModelsInvestments` 0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0).
+
 ## Version 0.7.6 (2025-02-10)
 
 * Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
-  * Increased version nubmer for EMB.
+  * Increased version number for `EMB`.
   * Model worked without adjustments.
   * Adjustments only required for simple understanding of changes.
 
-## Version 0.7.5 (2024-11-03)
+## Version 0.7.5 (2024-12-03)
 
 * Fix of a bug introduced in 0.7.4.
 * Adjusted the tests to identify similar bugs in later stages.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCO2"
 uuid = "84b3f4d7-d799-4a5d-b06c-25c90dcfcad7"
 authors = ["Sigmund Eggen Holm, Julian Straus"]
-version = "0.7.6"
+version = "0.8.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -10,7 +10,7 @@ SparseVariables = "2749762c-80ed-4b14-8f33-f0736679b02b"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.9"
+EnergyModelsBase = "0.10"
 JuMP = "1.5"
 TimeStruct = "0.9"
 julia = "1.10"

--- a/docs/src/nodes/retrofit.md
+++ b/docs/src/nodes/retrofit.md
@@ -41,7 +41,7 @@ The standard fields are given as:
       - [`CCSRetroFit`](@ref):\
         The capacity corresponds to the CO₂ flow rate handling capacity, **not** the CO₂ capture capacity
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\
@@ -98,7 +98,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-CCS_retrofit-math-var)
 
@@ -113,7 +113,7 @@ The variables include:
 - [``\texttt{cap\_inst}``](@extref EnergyModelsBase man-opt_var-cap)
 - [``\texttt{flow\_in}``](@extref EnergyModelsBase man-opt_var-flow)
 - [``\texttt{flow\_out}``](@extref EnergyModelsBase man-opt_var-flow)
-- [``\texttt{emissions\_node}``](@ref EnergyModelsBase man-opt_var-emissions)
+- [``\texttt{emissions\_node}``](@extref EnergyModelsBase man-opt_var-emissions)
 
 #### [Additional variables](@id nodes-CCS_retrofit-math-add)
 
@@ -368,7 +368,6 @@ while the CO₂ outlet flow is given as:
     \end{aligned}
     ```
 
-
 !!! info "data::CaptureProcessEnergyEmissions"
     The total produced CO₂ is calculated through an auxiliary expression as
 
@@ -392,7 +391,6 @@ while the CO₂ outlet flow is given as:
         \sum_{p_{in} \in P^{in}} co2\_int(p_{in}) \times \texttt{flow\_in}[n, t, p_{in}])
     \end{aligned}
     ```
-
 
 #### [Additional constraints](@id nodes-CCS_retrofit-math-con-add)
 

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -22,7 +22,7 @@ The standard fields are given as:
   If the node should contain investments through the application of [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/), it is important to note that you can only use `FixedProfile` or `StrategicProfile` for the capacity, but not `RepresentativeProfile` or `OperationalProfile`.
   In addition, all values have to be non-negative.
 - **`opex_var::TimeProfile`**:\
-  The variable operational expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
+  The variable operating expenses are based on the capacity utilization through the variable [`:cap_use`](@extref EnergyModelsBase man-opt_var-cap).
   Hence, it is directly related to the specified `output` ratios.
   The variable operating expenses can be provided as `OperationalProfile` as well.
 - **`opex_fixed::TimeProfile`**:\
@@ -62,7 +62,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-co2_source-math-var)
 

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -67,7 +67,7 @@ with square brackets, while functions are represented as
 
 ``func\_example(index_1, index_2)``
 
-with paranthesis.
+with parantheses.
 
 ### [Variables](@id nodes-co2_storage-math-var)
 

--- a/examples/ccs_retrofit.jl
+++ b/examples/ccs_retrofit.jl
@@ -41,7 +41,7 @@ function generate_co2_retrofit_example_data()
 
     # Variables for the individual entries of the time structure
     op_duration = 2 # Each operational period has a duration of 2 h
-    op_number = 4   # There are in total 5 operational periods in each strategic period
+    op_number = 4   # There are in total 4 operational periods in each strategic period
     operational_periods = SimpleTimes(op_number, op_duration)
 
     # The total time within a strategic period is given by 8760 h
@@ -50,8 +50,8 @@ function generate_co2_retrofit_example_data()
     op_per_strat = 8760
 
     # Creation of the time structure and global data
-    sp_duration = 10 # Each strategic period has a duration of 10 a
-    sp_number = 2   # There are in total 8 strategic periods
+    sp_duration = 10    # Each strategic period has a duration of 10 a
+    sp_number = 2       # There are in total 2 strategic periods
     T = TwoLevel(sp_number, sp_duration, operational_periods; op_per_strat)
 
     # Creation of the model type with global data


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [v0.10.0 EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0)

The adjustments did not require any changes except for dependency updates. It is however prudent to do a major version increase to maintain the potential for bug fixes in the previous version. In addition, the behavior may change when investments are included.