### PR TITLE
Improvement of `CO2Storage`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 * Added a check for using the correct `StorageBehavior` in `CO2Storage` when not utilizing the constructor.
+* Make the functions `previous_level` more restrictive on the `StorageBehavior` to allow for using other `Accumulating` behaviors.
 
 ## Version 0.8.0 (2026-04-13)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unversioned
+
+* Added a check for using the correct `StorageBehavior` in `CO2Storage` when not utilizing the constructor.
+
 ## Version 0.8.0 (2026-04-13)
 
 * Adjusted to [`EnergyModelsBase` v0.10.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 
 ## Unversioned
 
-* Added a check for using the correct `StorageBehavior` in `CO2Storage` when not utilizing the constructor.
-* Make the functions `previous_level` more restrictive on the `StorageBehavior` to allow for using other `Accumulating` behaviors.
+* Made the parametric composite type `CO2Storage` to require an `Accumulating` `StorageBehavior`.
+* Made the functions `previous_level` more restrictive on the `StorageBehavior` to allow for using other `Accumulating` behaviors.
 
 ## Version 0.8.0 (2026-04-13)
 

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -11,10 +11,11 @@ Hence, it is necessary to include a specific CO₂ storage node
 The [`CO2Storage`](@ref) node is similar to a [`RefStorage`](@extref EnergyModelsBase.RefStorage) with minor modifications to the implemented constraints.
 It introduces a new *[storage behavior](@extref EnergyModelsBase lib-pub-nodes-stor_behav)* to accomodate for the implementation of coupling the storage level balances between different strategic periods.
 This storage behavior is called [`EnergyModelsCO2.AccumulatingStrategic`](@ref).
+The [`CO2Storage`](@ref) node furthermore does not include an outflow.
 
 !!! info "`StorageBehaviour` for `CO2Storage` nodes"
     [`CO2Storage`](@ref) nodes utilize an outer constructor for specifying the storage behavior.
-    This means that they can be automatically created with [`EnergyModelsCO2.AccumulatingStrategic`](@ref).
+    This means that they can be automatically created with [`EnergyModelsCO2.AccumulatingStrategic`](@ref) without specifying it explicitly.
     If you plan to include a temporary CO₂ storage node, *e.g.* for storing captured CO₂ for subsequent utilization, it is best to utilize the [`RefStorage`](@extref EnergyModelsBase.RefStorage) node.
 
     The application of [`EnergyModelsRecedingHorizon`](https://github.com/EnergyModelsX/EnergyModelsRecedingHorizon.jl) requires you however to specify [`RecedingAccumulating`](https://github.com/EnergyModelsX/EnergyModelsRecedingHorizon.jl/blob/bc8832727c5df81f0f678618058bf524dc5d6987/src/structures/data.jl#L7).
@@ -302,4 +303,4 @@ In the case of CO₂ storage node, we can distinguish the following cases:
     prev\_level = \texttt{stor\_level}[n, t_{prev}]
    ```
 
-Cases 1 and 2 are implemented within `EnergyModelsCO2` for `CO2Storage` nodes while cases 3 and 4 are implemented in `EnergyModelsBase`.
+Cases 1 and 2 are implemented within `EnergyModelsCO2` for `CO2Storage{AccumulatingStrategic}` nodes while cases 3 and 4 are implemented in `EnergyModelsBase`.

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -23,35 +23,3 @@ function EMB.check_node(n::CO2Source, 𝒯, modeltype::EnergyModel, check_timepr
         "The `data` cannot include a `CaptureData`."
     )
 end
-
-"""
-    EMB.check_node(n::CO2Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
-
-This method checks that a [`CO2Storage`](@ref) node is valid.
-
-It reuses the standard checks of a `Source` node through calling the function
-[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
-additional check on the parametric type.
-
-## Checks
-- The `TimeProfile` of the field `capacity` in the type in the field `charge` is required
-  to be non-negative..
-- The `TimeProfile` of the field `capacity` in the type in the field `level` is required
-  to be non-negative`.
-- The `TimeProfile` of the field `fixed_opex` is required to be non-negative and
-  accessible through a `StrategicPeriod` as outlined in the function
-  `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)` for the chosen composite type.
-- The values of the dictionary `input` are required to be non-negative.
-- The specified storage [`Resource`](@extref EnergyModelsBase.Resource) must be included in
-  the dictionary `input`.
-- The specified [`StorageBehavior`](@extref EnergyModelsBase.StorageBehavior) must be a
-  subtype of `Accumulating`.
-"""
-function EMB.check_node(n::CO2Storage{T}, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) where {T}
-
-    EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
-    @assert_or_log(
-        T <: EMB.Accumulating,
-        "The `StorageBehavior` must be Accumulating."
-    )
-end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -23,3 +23,35 @@ function EMB.check_node(n::CO2Source, 𝒯, modeltype::EnergyModel, check_timepr
         "The `data` cannot include a `CaptureData`."
     )
 end
+
+"""
+    EMB.check_node(n::CO2Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+
+This method checks that a [`CO2Storage`](@ref) node is valid.
+
+It reuses the standard checks of a `Source` node through calling the function
+[`EMB.check_node_default`](@extref EnergyModelsBase.check_node_default), but adds an
+additional check on the parametric type.
+
+## Checks
+- The `TimeProfile` of the field `capacity` in the type in the field `charge` is required
+  to be non-negative..
+- The `TimeProfile` of the field `capacity` in the type in the field `level` is required
+  to be non-negative`.
+- The `TimeProfile` of the field `fixed_opex` is required to be non-negative and
+  accessible through a `StrategicPeriod` as outlined in the function
+  `check_fixed_opex(n, 𝒯ᴵⁿᵛ, check_timeprofiles)` for the chosen composite type.
+- The values of the dictionary `input` are required to be non-negative.
+- The specified storage [`Resource`](@extref EnergyModelsBase.Resource) must be included in
+  the dictionary `input`.
+- The specified [`StorageBehavior`](@extref EnergyModelsBase.StorageBehavior) must be a
+  subtype of `Accumulating`.
+"""
+function EMB.check_node(n::CO2Storage{T}, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool) where {T}
+
+    EMB.check_node_default(n, 𝒯, modeltype, check_timeprofiles)
+    @assert_or_log(
+        T <: EMB.Accumulating,
+        "The `StorageBehavior` must be Accumulating."
+    )
+end

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -1,11 +1,11 @@
 
 """
-    AccumulatingStrategic <: EMB.Accumulating
+    AccumulatingStrategic <: Accumulating
 
 `StorageBehavior` which accumulates all inflow within a strategic period and transfers the
 level to the next strategic period. This approach is used for [`CO2Storage`](@ref) nodes.
 """
-struct AccumulatingStrategic <: EMB.Accumulating end
+struct AccumulatingStrategic <: Accumulating end
 
 """
     CO2Source <: Source
@@ -41,14 +41,14 @@ function CO2Source(
 end
 
 """
-    CO2Storage{T} <: Storage{T}
+    CO2Storage{T<:Accumulating} <: Storage{T}
 
 This node has an installed injection rate capacity through `charge` and a storage capacity
 `level`.
 
 The storage level (accountet by the optimization variable `stor_level`) will
 increase during all strategic periods (sp), *i.e.*, the stored resource can not be
-taken out of the storage.
+taken out of the storage. It requires hence to use an `Accumulating` `StorageBehavior`.
 
 The initial storage level in a strategic period is set to the storage level at
 the end of the previous sp. Note that the increased storage level during a sp
@@ -71,7 +71,7 @@ is not a required input due to the utilization of an outer constructor.
 - **`data::Array{<:Data}`** is the additional data (e.g. for investments). The field `data`
   is conditional through usage of a constructor.
 """
-struct CO2Storage{T} <: Storage{T}
+struct CO2Storage{T<:Accumulating} <: Storage{T}
     id::Any
 
     charge::EMB.UnionCapacity

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,7 +22,7 @@ analysis.
 """
 function EMB.previous_level(
     m,
-    n::CO2Storage,
+    n::CO2Storage{AccumulatingStrategic},
     prev_pers::PreviousPeriods{Nothing,Nothing,Nothing},
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,
@@ -38,7 +38,7 @@ strategic periods.
 """
 function EMB.previous_level(
     m,
-    n::CO2Storage,
+    n::CO2Storage{AccumulatingStrategic},
     prev_pers::PreviousPeriods{<:TS.AbstractStrategicPeriod,Nothing,Nothing},
     cyclic_pers::CyclicPeriods,
     modeltype::EnergyModel,

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -6,7 +6,7 @@ EMB.TEST_ENV = true
 @testset "Test checks - CO2Source" begin
 
     # Resources used in the checks
-    CO2 = ResourceEmit("CO2", 1.0)
+    CO2 = ResourceEmit("CO₂", 1.0)
     Power = ResourceCarrier("Power", 0.0)
 
     # Simple graph for testing the individual checks
@@ -17,7 +17,7 @@ EMB.TEST_ENV = true
         data = Data[],
 
     )
-        resources = [CO2]
+        products = [CO2]
         ops = SimpleTimes(5, 2)
         T = TwoLevel(2, 2, ops; op_per_strat=10)
 
@@ -50,6 +50,50 @@ EMB.TEST_ENV = true
     # Test that a wrong fixed data is caught by the checks.
     @test_throws AssertionError simple_graph(;data=Data[CaptureEnergyEmissions(0.9)])
 
+end
+
+# Test that the fields of a CO2Storage are correctly checked
+# - EMB.check_node(n::CO2Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+@testset "Test checks - CO2Storage" begin
+
+    # Resources used in the checks
+    CO2 = ResourceEmit("CO₂", 1.0)
+    power = ResourceCarrier("Power", 0.0)
+    CO2_2 = ResourceEmit("CO₂_2", 1.0)
+
+    # Simple graph for testing the individual checks
+    function simple_graph(;
+        stor_res = CO2,
+        stor_behavior = EMC.AccumulatingStrategic,
+    )
+        products = [CO2, power]
+        ops = SimpleTimes(5, 2)
+        T = TwoLevel(2, 2, ops; op_per_strat=10)
+
+        nodes = [
+            CO2Storage{stor_behavior}(
+                "storage",
+                StorCapOpex(FixedProfile(10), FixedProfile(2), FixedProfile(1)),
+                StorCap(FixedProfile(10)),
+                stor_res,
+                Dict(CO2 => 1, power => 0.02),
+            )
+        ]
+        links = Link[]
+        model = OperationalModel(
+            Dict(CO2 => FixedProfile(100)),
+            Dict(CO2 => FixedProfile(0)),
+            CO2
+        )
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
+        return create_model(case, model), case, model
+    end
+
+    # Test that `check_node_default` is correctly called
+    @test_throws AssertionError simple_graph(;stor_res=CO2_2)
+
+    # Test that a wrong fixed data is caught by the checks.
+    @test_throws AssertionError simple_graph(;stor_behavior=CyclicStrategic)
 end
 
 # Set the global again to false

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -52,8 +52,8 @@ EMB.TEST_ENV = true
 
 end
 
-# Test that the fields of a CO2Storage are correctly checked
-# - EMB.check_node(n::CO2Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
+# Test that the fields of a Storage are correctly checked
+# - EMB.check_node_default(n::Storage, 𝒯, modeltype::EnergyModel, check_timeprofiles::Bool)
 @testset "Test checks - CO2Storage" begin
 
     # Resources used in the checks
@@ -64,14 +64,13 @@ end
     # Simple graph for testing the individual checks
     function simple_graph(;
         stor_res = CO2,
-        stor_behavior = EMC.AccumulatingStrategic,
     )
         products = [CO2, power]
         ops = SimpleTimes(5, 2)
         T = TwoLevel(2, 2, ops; op_per_strat=10)
 
         nodes = [
-            CO2Storage{stor_behavior}(
+            CO2Storage(
                 "storage",
                 StorCapOpex(FixedProfile(10), FixedProfile(2), FixedProfile(1)),
                 StorCap(FixedProfile(10)),
@@ -91,9 +90,6 @@ end
 
     # Test that `check_node_default` is correctly called
     @test_throws AssertionError simple_graph(;stor_res=CO2_2)
-
-    # Test that a wrong fixed data is caught by the checks.
-    @test_throws AssertionError simple_graph(;stor_behavior=CyclicStrategic)
 end
 
 # Set the global again to false


### PR DESCRIPTION
This PR adds 2 features for `CO2Storage`:

1. Restricting `CO2Storage` to have an `Accumulating` storage behavior to avoid `CO2Storage` nodes where no storage could take place.
2. Make the version of `previous_level` more restrictive with respect to arguments to avoid problems for different `StorageBehavior` types as could be a problem with the *[version of `EnergyModelsRecedingHorizon`](https://github.com/EnergyModelsX/EnergyModelsRecedingHorizon.jl/blob/901a51e5af3ad8491c640cc34799ba796355f845/src/utils/other.jl#L1)*.