### PR TITLE
Adjustment to name change of `Data`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # Release Notes
 
-## Unversioned
+## Version 0.9.0 (2026-06-04)
 
+* Renamed `Data` to `ExtensionData` and `constraints_data` to `constraints_ext_data` as introduced in [`EnergyModelsBase` v0.9.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.1).
+  This simplifies future maintainability.
 * Made the parametric composite type `CO2Storage` to require an `Accumulating` `StorageBehavior`.
 * Made the functions `previous_level` more restrictive on the `StorageBehavior` to allow for using other `Accumulating` behaviors.
 
@@ -117,7 +119,8 @@
 ### Switch to `TimeStruct`
 
 * Switched the time structure representation to `TimeStruct`.
-* `TimeStruct` is implemented with only the basis features that were available in `TimesStructures`. This implies that neither operational nor strategic uncertainty is included in the model.
+* `TimeStruct` is implemented with only the basis features that were available in `TimesStructures`.
+  This implies that neither operational nor strategic uncertainty is included in the model.
 
 ## Version 0.2.0 (2023-05-30)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsCO2"
 uuid = "84b3f4d7-d799-4a5d-b06c-25c90dcfcad7"
 authors = ["Sigmund Eggen Holm, Julian Straus"]
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/how-to/incorporate_retrofit.md
+++ b/docs/src/how-to/incorporate_retrofit.md
@@ -11,14 +11,14 @@ The new type only has the following requirements:
 1. Is has to be a subtype of [`NetworkNodeWithRetrofit`](@ref).
    This implies that said node is a `NetworkNode`, although we are currently thinking about changing the overall structure.
 2. The type **must** have either a field called `co2_proxy` or you have to add a method to the function [`EnergyModelsCO2.co2_proxy`](@ref) of `EnergyModelsCO2`.
-3. CO₂ capture data has to be incorporated as one of the [`CaptureData`](@extref EnergyModelsBase.CaptureData) subtypes  as described on *[Data functions](@extref EnergyModelsBase man-data_fun)*.
+3. CO₂ capture data has to be incorporated as one of the [`CaptureData`](@extref EnergyModelsBase.CaptureData) subtypes  as described on *[ExtensionData functions](@extref EnergyModelsBase man-data_fun)*.
 4. If you have created a new method for  [`EnergyModelsBase.create_node`](@extref EnergyModelsBase), you have to include in said method the following code lines
 
    ```julia
    for data ∈ node_data(n)
-       constraints_data(m, n, 𝒯, 𝒫, modeltype, data)
+       constraints_ext_data(m, n, 𝒯, 𝒫, modeltype, data)
    end
    ```
 
    and the node **must** have either a field called `data` or you have to add a method to the function [`EnergyModelsBase.node_data`](@extref EnergyModelsBase) to be able to access the data.\
-   Alternatively, you can also manually extract the capture data and call directlty the functions [`constraints_data`](@extref EnergyModelsBase.constraints_data)
+   Alternatively, you can also manually extract the capture data and call directlty the functions [`constraints_ext_data`](@extref EnergyModelsBase.constraints_ext_data)

--- a/docs/src/library/internals/methods-EMB.md
+++ b/docs/src/library/internals/methods-EMB.md
@@ -19,7 +19,7 @@ EnergyModelsBase.create_node
 EnergyModelsBase.constraints_flow_out
 EnergyModelsBase.constraints_level_aux
 EnergyModelsBase.constraints_capacity
-EnergyModelsBase.constraints_data
+EnergyModelsBase.constraints_ext_data
 ```
 
 ## [Utility methods](@id int-methods_EMB-util)

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -29,7 +29,7 @@ CCSRetroFit
 NetworkCCSRetrofit
 ```
 
-## [Data types](@id lib-pub-data)
+## [ExtensionData types](@id lib-pub-data)
 
 ### [`CaptureData` for `CCSRetrofit`](@id lib-pub-data-em_data)
 

--- a/docs/src/nodes/retrofit.md
+++ b/docs/src/nodes/retrofit.md
@@ -64,7 +64,7 @@ The standard fields are given as:
         The CO₂ proxy resource is automatically included in the `input` dictionary through providing additional methods to `EMB.inputs`.
         Requires the incorporation of the  CO₂ resource in the `output` dictionary, although the exact value is not relevant.
         It is furthermore possible to specify additional reenergy required for capturing CO₂ using a conversion factor (*e.g.*, MWh/t CO₂).
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   The `data` vector must include [`CaptureData`](@extref EnergyModelsBase.CaptureData) for both [`RefNetworkNodeRetrofit`](@ref) and [`CCSRetroFit`](@ref).
   It can include additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
@@ -185,12 +185,12 @@ These standard constraints are:
       The function [``scale\_op\_sp(t_{inv}, t)``](@extref EnergyModelsBase.scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified data of the nodes, see above.
   This function is extended with multiple methods for both `CCSRetroFit` and `RefNetworkNodeRetrofit`.
   The individual methods are explained below.
 
-The outlet flow constraint for a [`RefNetworkNodeRetrofit`](@ref) node is requires introducing new methods for the function `constraints_flow_out` as the outlet flow of the CO₂ proxy is calculated in the function `constraints_data` as outlined in *[Standard constraints](@ref nodes-CCS_retrofit-math-con-stand)*.
+The outlet flow constraint for a [`RefNetworkNodeRetrofit`](@ref) node is requires introducing new methods for the function `constraints_flow_out` as the outlet flow of the CO₂ proxy is calculated in the function `constraints_ext_data` as outlined in *[Standard constraints](@ref nodes-CCS_retrofit-math-con-stand)*.
 This constraint is given by:
 
 ```math
@@ -199,7 +199,7 @@ outputs(n, p) \times \texttt{cap\_use}[n, t]
 \qquad \forall p \in outputs(n) \setminus \{co2\_proxy(n)\}
 ```
 
-The introduction of the CO₂ capture unit as retrofit option requires introducing new methods for the function `constraints_data` for all [`CaptureData`](@extref EnergyModelsBase.CaptureData) as described on *[Data functions](@extref EnergyModelsBase man-data_fun-emissions)*.
+The introduction of the CO₂ capture unit as retrofit option requires introducing new methods for the function `constraints_ext_data` for all [`CaptureData`](@extref EnergyModelsBase.CaptureData) as described on *[ExtensionData functions](@extref EnergyModelsBase man-data_fun-emissions)*.
 In all methods, the process emissions of the other [`ResourceEmit`](@extref EnergyModelsBase.ResourceEmit)s, that is all emissions resources except for CO₂, are calculated as
 
 ```math
@@ -396,7 +396,7 @@ while the CO₂ outlet flow is given as:
 
 ##### [Constraints calculated in `create_node`](@id nodes-CCS_retrofit-math-con-add-node)
 
-The inlet flow constraint for a [`CCSRetroFit`](@ref) node is calculated separately as the inlet flow of the CO₂ proxy is calculated in the function `constraints_data` as outlined in *[Standard constraints](@ref nodes-CCS_retrofit-math-con-stand)*.
+The inlet flow constraint for a [`CCSRetroFit`](@ref) node is calculated separately as the inlet flow of the CO₂ proxy is calculated in the function `constraints_ext_data` as outlined in *[Standard constraints](@ref nodes-CCS_retrofit-math-con-stand)*.
 This constraint is given by:
 
 ```math

--- a/docs/src/nodes/source.md
+++ b/docs/src/nodes/source.md
@@ -34,7 +34,7 @@ The standard fields are given as:
   In the case of a CO₂ source, `output` should always include *CO₂*.
   It is also possible to include other resources which are produced with a given correlation with CO₂.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is only relevant for additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used or for additional emission data through [`EmissionsProcess`](@extref EnergyModelsBase.EmissionsProcess).
   The latter would correspond to uncaptured CO₂ that should be included in the analyses.
@@ -133,7 +133,7 @@ These standard constraints are:
       The function [``scale\_op\_sp(t_{inv}, t)``](@extref EnergyModelsBase.scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified data of the CO₂ source, see above.
 
 The function `constraints_flow_out` is extended with a new method for CO₂ source nodes to allow the inclusion of CO₂:

--- a/docs/src/nodes/storage.md
+++ b/docs/src/nodes/storage.md
@@ -46,7 +46,7 @@ The standard fields are given as:
   It is also possible to include other resources which are required with a given correlation to the stored CO₂.
   One example would be *Power* in the case of electricity requirements for storing CO₂.\
   All values have to be non-negative.
-- **`data::Vector{Data}`**:\
+- **`data::Vector{ExtensionData}`**:\
   An entry for providing additional data to the model.
   In the current version, it is only relevant for additional investment data when [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/) is used.
 
@@ -161,7 +161,7 @@ These standard constraints are:
       The function [``scale\_op\_sp(t_{inv}, t)``](@extref EnergyModelsBase.scale_op_sp) calculates the scaling factor between operational and strategic periods.
       It also takes into account potential operational scenarios and their probability as well as representative periods.
 
-- `constraints_data`:\
+- `constraints_ext_data`:\
   This function is only called for specified data of the CO₂ storage node, see above.
 
 !!! info "Implementation of OPEX"

--- a/examples/ccs_retrofit.jl
+++ b/examples/ccs_retrofit.jl
@@ -78,7 +78,7 @@ function generate_co2_retrofit_example_data()
             # Line above: CO2_proxy does not have to be specified as we add a method to
             # `EMB.outputs`
             CO2_proxy,                  # Instance of the `CO2_proxy`
-            Data[CaptureEnergyEmissions(1.0)], # Capture data for the node.
+            ExtensionData[CaptureEnergyEmissions(1.0)], # Capture data for the node.
             # All energy emissions are captured
         ),
         CCSRetroFit(
@@ -92,7 +92,7 @@ function generate_co2_retrofit_example_data()
             # Line above: CO2 is required as input for variable definition, but the
             # value does not matter
             CO2_proxy,                  # Instance of the `CO2_proxy`
-            Data[CaptureEnergyEmissions(0.9)], # Capture data for the node.
+            ExtensionData[CaptureEnergyEmissions(0.9)], # Capture data for the node.
             # All energy emission from the energy to the `CCSRetroFit` are captured.
         ),
         CO2Storage(

--- a/src/constraint_functions.jl
+++ b/src/constraint_functions.jl
@@ -3,7 +3,7 @@
 
 Function for creating the constraint on the outlet flow from `CO2Source`.
 The standard `constraints_flow_out` function does not allow CO₂ as an outlet flow as the
-CO₂ outlet flow is specified in the `constraints_data` function to implement CO₂ capture.
+CO₂ outlet flow is specified in the `constraints_ext_data` function to implement CO₂ capture.
 """
 function EMB.constraints_flow_out(m, n::CO2Source, 𝒯::TimeStructure, modeltype::EnergyModel)
     # Declaration of the required subsets, excluding CO2, if specified
@@ -52,7 +52,6 @@ Function for creating the Δ constraint for the level of a reference storage nod
 function EMB.constraints_level_aux(m, n::CO2Storage, 𝒯, 𝒫, modeltype::EnergyModel)
     # Declaration of the required subsets
     𝒯ᴵⁿᵛ = strategic_periods(𝒯)
-    p_stor = storage_resource(n)
 
     # Constraint for the change in the level in a given operational period
     @constraint(m, [t ∈ 𝒯],

--- a/src/data_functions.jl
+++ b/src/data_functions.jl
@@ -1,6 +1,6 @@
 
 """
-    EMB.constraints_data(
+    EMB.constraints_ext_data(
         m,
         n::NetworkNodeWithRetrofit,
         𝒯,
@@ -16,7 +16,7 @@ process when CO₂ capture is included as retrofit. It works similar to the appr
 The functions are updated for a [`NetworkNodeWithRetrofit`](@ref)-node as the output is the
 CO₂ proxy and not CO₂.
 """
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::NetworkNodeWithRetrofit,
     𝒯,
@@ -51,7 +51,7 @@ function EMB.constraints_data(
     # Constraint for the outlet of the CO2 proxy
     @constraint(m, [t ∈ 𝒯], m[:flow_out][n, t, CO2_proxy] == CO2_tot[t] * co2_capture(data))
 end
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::NetworkNodeWithRetrofit,
     𝒯,
@@ -87,7 +87,7 @@ function EMB.constraints_data(
     # Constraint for the outlet of the CO2 proxy
     @constraint(m, [t ∈ 𝒯], m[:flow_out][n, t, CO2_proxy] == CO2_tot[t] * co2_capture(data))
 end
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::NetworkNodeWithRetrofit,
     𝒯,
@@ -125,7 +125,7 @@ function EMB.constraints_data(
 end
 
 """
-    EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsData)
+    EMB.constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::EmissionsData)
 
 Constraints functions for calculating both the emissions and amount of CO₂ captured in the
 CO₂ capture unit.
@@ -143,7 +143,7 @@ There exist several configurations for incorporation of CO₂ capture:
 The functions are updated for a `CCSRetroFit`-node as CO₂ emissions require a different
 calculation due to the inclusion of the CO₂ proxy resource for the flue gas.
 """
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::CCSRetroFit,
     𝒯,
@@ -195,7 +195,7 @@ function EMB.constraints_data(
             )
     )
 end
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::CCSRetroFit,
     𝒯,
@@ -246,7 +246,7 @@ function EMB.constraints_data(
             )
     )
 end
-function EMB.constraints_data(
+function EMB.constraints_ext_data(
     m,
     n::CCSRetroFit,
     𝒯,
@@ -296,7 +296,7 @@ function EMB.constraints_data(
             )
     )
 end
-function EMB.constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureFlueGas)
+function EMB.constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel, data::CaptureFlueGas)
 
     # Declaration of the required subsets.
     CO2 = co2_instance(modeltype)

--- a/src/datastructures.jl
+++ b/src/datastructures.jl
@@ -19,7 +19,7 @@ is that is allows for CO₂ as outlet.
 - **`opex_var::TimeProfile`** is the variational operational costs per energy unit produced.
 - **`opex_fixed::TimeProfile`** is the fixed operational costs.
 - **`output::Dict{<:Resource, <:Real}`** are the generated `Resource`s with conversion value `Real`.
-- **`data::Array{<:Data}`** is the additional data (e.g. for investments). The field `data`
+- **`data::Array{<:ExtensionData}`** is the additional data (e.g. for investments). The field `data`
   is conditional through usage of a constructor.
 """
 struct CO2Source <: Source
@@ -28,7 +28,7 @@ struct CO2Source <: Source
     opex_var::TimeProfile
     opex_fixed::TimeProfile
     output::Dict{<:Resource,<:Real}
-    data::Array{<:Data}
+    data::Array{<:ExtensionData}
 end
 function CO2Source(
     id::Any,
@@ -37,7 +37,7 @@ function CO2Source(
     opex_fixed::TimeProfile,
     output::Dict{<:Resource,<:Real},
 )
-    return CO2Source(id, cap, opex_var, opex_fixed, output, Data[])
+    return CO2Source(id, cap, opex_var, opex_fixed, output, ExtensionData[])
 end
 
 """
@@ -68,7 +68,7 @@ is not a required input due to the utilization of an outer constructor.
   fixed OPEX.
 - **`stor_res::Resource`** is the stored `Resource`.
 - **`input::Dict{<:Resource, <:Real}`** are the input `Resource`s with conversion value `Real`.
-- **`data::Array{<:Data}`** is the additional data (e.g. for investments). The field `data`
+- **`data::Array{<:ExtensionData}`** is the additional data (e.g. for investments). The field `data`
   is conditional through usage of a constructor.
 """
 struct CO2Storage{T<:Accumulating} <: Storage{T}
@@ -79,7 +79,7 @@ struct CO2Storage{T<:Accumulating} <: Storage{T}
 
     stor_res::ResourceEmit
     input::Dict{<:Resource,<:Real}
-    data::Array{<:Data}
+    data::Array{<:ExtensionData}
 end
 function CO2Storage{T}(
     id,
@@ -94,7 +94,7 @@ function CO2Storage{T}(
         level,
         stor_res,
         input,
-        Data[],
+        ExtensionData[],
     )
 end
 function CO2Storage(
@@ -103,7 +103,7 @@ function CO2Storage(
     level::EMB.UnionCapacity,
     stor_res::Resource,
     input::Dict{<:Resource,<:Real},
-    data=Data[],
+    data=ExtensionData[],
 )
     return CO2Storage{AccumulatingStrategic}(
         id,
@@ -164,7 +164,7 @@ The `co2_proxy` does not have to be specified as `output` resource.
   `co2_proxy` is required to be included to be available to have CO₂ capture applied properly.
 - **`co2_proxy::Resource`** is the instance of the `Resource` used for calculating internally
   the CO₂ flow from the `RefNetworkNodeRetrofit` to the `CCSRetroFit` node.
-- **`data::Array{<:Data}`** is the additional data (e.g. for investments).
+- **`data::Array{<:ExtensionData}`** is the additional data (e.g. for investments).
 """
 struct RefNetworkNodeRetrofit <: NetworkNodeWithRetrofit
     id::Any
@@ -174,7 +174,7 @@ struct RefNetworkNodeRetrofit <: NetworkNodeWithRetrofit
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
     co2_proxy::Resource
-    data::Array{<:Data}
+    data::Array{<:ExtensionData}
 end
 
 """
@@ -209,7 +209,7 @@ The `co2_proxy` does not have to be specified as `input` resource.
   properly.
 - **`co2_proxy::Resource`** is the instance of the `Resource` used for calculating internally
   the CO₂ flow from the `RefNetworkNodeRetrofit` to the `CCSRetroFit` node.
-- **`data::Array{<:Data}`** is the additional data (e.g. for investments).
+- **`data::Array{<:ExtensionData}`** is the additional data (e.g. for investments).
 """
 struct CCSRetroFit <: NetworkNode
     id::Any
@@ -219,7 +219,7 @@ struct CCSRetroFit <: NetworkNode
     input::Dict{<:Resource,<:Real}
     output::Dict{<:Resource,<:Real}
     co2_proxy::Resource
-    data::Array{<:Data}
+    data::Array{<:ExtensionData}
 end
 
 """

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -8,7 +8,7 @@
         stor_res::ResourceCarrier,
         input::Dict{<:Resource,<:Real},
         output::Dict{<:Resource,<:Real},
-        data::Array{<:Data},
+        data::Array{<:ExtensionData},
     )
 
 Legacy constructor for a `CO2Storage`.
@@ -26,7 +26,7 @@ function CO2Storage(
     stor_res::Resource,
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
-    data::Array{<:Data},
+    data::Array{<:ExtensionData},
 )
     @warn(
         "The used implementation of a `CO2Storage` will be discontinued in the near future.\n" *
@@ -55,7 +55,7 @@ function CO2Storage(
     opex_fixed::TimeProfile,
     stor_res::Resource,
     input::Dict{<:Resource,<:Real},
-    data::Array{<:Data},
+    data::Array{<:ExtensionData},
 )
     @warn(
         "The used implementation of a `CO2Storage` will be discontinued in the near future.\n" *

--- a/src/model.jl
+++ b/src/model.jl
@@ -28,7 +28,7 @@ node through modifying the flow to the node and not calling the functions
 replaced with constraints directly within the function.
 
 # Called constraint functions
-- [`constraints_data`](@extref EnergyModelsBase.constraints_data) for all `node_data(n)`,
+- [`constraints_ext_data`](@extref EnergyModelsBase.constraints_ext_data) for all `node_data(n)`,
 - [`constraints_level`](@extref EnergyModelsBase.constraints_level),
 - [`constraints_capacity`](@extref EnergyModelsBase.constraints_capacity),
 - [`constraints_opex_fixed`](@extref EnergyModelsBase.constraints_opex_fixed), and
@@ -44,7 +44,7 @@ function EMB.create_node(m, n::CO2Storage, 𝒯, 𝒫, modeltype::EnergyModel)
 
     # Iterate through all data and set up the constraints corresponding to the data
     for data ∈ node_data(n)
-        constraints_data(m, n, 𝒯, 𝒫, modeltype, data)
+        constraints_ext_data(m, n, 𝒯, 𝒫, modeltype, data)
     end
 
     # Set the lower bound for the CO2 emissions in the storage node (:emissions_node)
@@ -93,7 +93,7 @@ to the node for the CO₂ proxy resource. The function
 [`constraints_flow_in`](@extref EnergyModelsBase.constraints_flow_in) is hence not called.
 
 # Called constraint functions
-- [`constraints_data`](@extref EnergyModelsBase.constraints_data) for all `node_data(n)`,
+- [`constraints_ext_data`](@extref EnergyModelsBase.constraints_ext_data) for all `node_data(n)`,
 - [`constraints_flow_out`](@extref EnergyModelsBase.constraints_flow_out),
 - [`constraints_capacity`](@extref EnergyModelsBase.constraints_capacity),
 - [`constraints_opex_fixed`](@extref EnergyModelsBase.constraints_opex_fixed), and
@@ -108,11 +108,11 @@ function EMB.create_node(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype::EnergyModel)
 
     # Iterate through all data and set up the constraints corresponding to the data
     for data ∈ node_data(n)
-        constraints_data(m, n, 𝒯, 𝒫, modeltype, data)
+        constraints_ext_data(m, n, 𝒯, 𝒫, modeltype, data)
     end
 
     # Inlet constraints for all other resources
-    # The value for `CO2_proxy` is calculated in `constraints_data`.
+    # The value for `CO2_proxy` is calculated in `constraints_ext_data`.
     @constraint(m, [t ∈ 𝒯, p ∈ 𝒫ⁱⁿ],
         m[:flow_in][n, t, p] == m[:cap_use][n, t] * inputs(n, p)
     )

--- a/test/test_ccs_retrofit.jl
+++ b/test/test_ccs_retrofit.jl
@@ -102,7 +102,7 @@ end
     T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:flow_out][process, t, CO2_proxy]) ≈
         value.(m[:flow_in][process, t, NG]) * co2_int(NG) * co2_capture(process.data[1]) for
@@ -110,7 +110,7 @@ end
     )
 
     # Test that the emissions are correct in the process node
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:emissions_node][process, t, CO2]) ≈
         value.(m[:flow_in][process, t, NG]) *
@@ -119,7 +119,7 @@ end
     )
 
     # Test that the emissions are correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureFlueGas)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureFlueGas)
     @test all(
         value.(m[:emissions_node][ccs, t, CO2]) ≈
         value.(m[:flow_in][ccs, t, CO2_proxy]) -
@@ -130,7 +130,7 @@ end
     )
 
     # Test that the capture is correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureFlueGas)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureFlueGas)
     @test all(
         value.(m[:flow_out][ccs, t, CO2]) ≈
         value.(m[:cap_use][ccs, t]) * co2_capture(ccs.data[1]) for t ∈ T, atol ∈ TEST_ATOL
@@ -154,7 +154,7 @@ end
     T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:flow_out][process, t, CO2_proxy]) ≈
         value.(m[:flow_in][process, t, NG]) * co2_int(NG) * co2_capture(process.data[1]) for
@@ -162,7 +162,7 @@ end
     )
 
     # Test that the emissions are correct in the process node
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:emissions_node][process, t, CO2]) ≈
         value.(m[:flow_in][process, t, NG]) *
@@ -173,7 +173,7 @@ end
     )
 
     # Test that the emissions are correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:emissions_node][ccs, t, CO2]) ≈
         value.(m[:flow_in][ccs, t, CO2_proxy]) -
@@ -184,7 +184,7 @@ end
     )
 
     # Test that the capture is correct in the ccs node and at its maximum
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:flow_out][ccs, t, CO2]) ≈
         (value.(m[:cap_use][ccs, t]) + value.(m[:flow_in][ccs, t, NG]) * co2_int(NG)) *
@@ -213,7 +213,7 @@ end
     T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
     @test all(
         value.(m[:flow_out][process, t, CO2_proxy]) ≈
             value.(m[:cap_use][process, t]) * process_emissions(process.data[1], CO2, t) *
@@ -221,7 +221,7 @@ end
     )
 
     # Test that the emissions are correct in the process node
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
     @test all(
         value.(m[:emissions_node][process, t, CO2]) ≈
             value.(m[:flow_in][process, t, NG]) * co2_int(NG) +
@@ -230,7 +230,7 @@ end
     )
 
     # Test that the emissions are correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
     @test all(
         value.(m[:emissions_node][ccs, t, CO2]) ≈
             value.(m[:flow_in][ccs, t, CO2_proxy]) -
@@ -241,7 +241,7 @@ end
     )
 
     # Test that the capture is correct in the ccs node and at its maximum
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEmissions)
     @test all(
         value.(m[:flow_out][ccs, t, CO2]) ≈
             value.(m[:cap_use][ccs, t]) * co2_capture(ccs.data[1]) +
@@ -271,7 +271,7 @@ end
     T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
     @test all(
         value.(m[:flow_out][process, t, CO2_proxy]) ≈
         (
@@ -281,7 +281,7 @@ end
     )
 
     # Test that the emissions are correct in the process node
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
     @test all(
         value.(m[:emissions_node][process, t, CO2]) ≈
         (
@@ -291,7 +291,7 @@ end
     )
 
     # Test that the emissions are correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
     @test all(
         value.(m[:emissions_node][ccs, t, CO2]) ≈
         value.(m[:flow_in][ccs, t, CO2_proxy]) -
@@ -303,7 +303,7 @@ end
     )
 
     # Test that the capture is correct in the ccs node and at its maximum
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureProcessEnergyEmissions)
     @test all(
         value.(m[:flow_out][ccs, t, CO2]) ≈
         value.(m[:cap_use][ccs, t]) * co2_capture(ccs.data[1]) +
@@ -328,7 +328,7 @@ end
         input::Dict{<:Resource,<:Real}
         output::Dict{<:Resource,<:Real}
         co2_proxy::Resource
-        data::Array{<:Data}
+        data::Array{<:ExtensionData}
     end
 
 
@@ -357,7 +357,7 @@ end
     T = get_time_struct(case)
 
     # Test that the outflow of the proxy is correct based on the capture rate
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:flow_out][process, t, CO2_proxy]) ≈
         value.(m[:flow_in][process, t, NG]) * co2_int(NG) * co2_capture(process.data[1]) for
@@ -365,7 +365,7 @@ end
     )
 
     # Test that the emissions are correct in the process node
-    # - constraints_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::RefNetworkNodeRetrofit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:emissions_node][process, t, CO2]) ≈
         value.(m[:flow_in][process, t, NG]) *
@@ -376,7 +376,7 @@ end
     )
 
     # Test that the emissions are correct in the ccs node
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:emissions_node][ccs, t, CO2]) ≈
         value.(m[:flow_in][ccs, t, CO2_proxy]) -
@@ -387,7 +387,7 @@ end
     )
 
     # Test that the capture is correct in the ccs node and at its maximum
-    # - constraints_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
+    # - constraints_ext_data(m, n::CCSRetroFit, 𝒯, 𝒫, modeltype, data::CaptureEnergyEmissions)
     @test all(
         value.(m[:flow_out][ccs, t, CO2]) ≈
         (value.(m[:cap_use][ccs, t]) + value.(m[:flow_in][ccs, t, NG]) * co2_int(NG)) *

--- a/test/test_checks.jl
+++ b/test/test_checks.jl
@@ -14,7 +14,7 @@ EMB.TEST_ENV = true
         cap = FixedProfile(10),
         opex_fixed = FixedProfile(0),
         output = Dict(CO2 => 1),
-        data = Data[],
+        data = ExtensionData[],
 
     )
         products = [CO2]
@@ -48,7 +48,7 @@ EMB.TEST_ENV = true
     @test_throws AssertionError simple_graph(;output = Dict(CO2 => 1, Power => -5))
 
     # Test that a wrong fixed data is caught by the checks.
-    @test_throws AssertionError simple_graph(;data=Data[CaptureEnergyEmissions(0.9)])
+    @test_throws AssertionError simple_graph(;data=ExtensionData[CaptureEnergyEmissions(0.9)])
 
 end
 


### PR DESCRIPTION
This PR adjusts to the changes to the `ExtensionData` names introduced  in [`EnergyModelsBase` v0.9.1](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.1). While this is not strictly speaking breaking, the changing of the behavior of `CO2Storage` in #14 in combination with the renaming was considered sufficient to warrant a breaking release.